### PR TITLE
Add "expand" to search

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -169,6 +169,7 @@ eventbriteAPI_v3.prototype.search = function (params, callback) {
     "date_modified.range_start", //Only return events with date_modified after the given UTC date.
     "date_modified.range_end", //Only return events with date_modified before the given UTC date.
     "date_modified.keyword", //Only return events with date_modified within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
+    "expand" //Optional comma-separated expansions as specified here: https://www.eventbrite.com/developer/v3/formats/event/#ebapi-public-expansions
   ];
 
   this.get("events", "search", availableParams, params, callback);


### PR DESCRIPTION
This is a simple easy one—`expand` was missing from the `availableParams` params array in the `search` method, so it was getting stripped out with each request. This PR simply adds it to the array.
